### PR TITLE
Fix invalid assertion

### DIFF
--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -193,7 +193,7 @@ class PersistentTabView extends PersistentTabViewBase {
     assert(
         routeAndNavigatorSettings.navigatorKeys == null ||
             routeAndNavigatorSettings.navigatorKeys != null &&
-                routeAndNavigatorSettings.navigatorKeys.length != items.length,
+                routeAndNavigatorSettings.navigatorKeys.length != itemCount,
         "Number of 'Navigator Keys' must be equal to the number of bottom navigation tabs.");
   }
 }

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -193,7 +193,7 @@ class PersistentTabView extends PersistentTabViewBase {
     assert(
         routeAndNavigatorSettings.navigatorKeys == null ||
             routeAndNavigatorSettings.navigatorKeys != null &&
-                routeAndNavigatorSettings.navigatorKeys.length != itemCount,
+                routeAndNavigatorSettings.navigatorKeys.length == itemCount,
         "Number of 'Navigator Keys' must be equal to the number of bottom navigation tabs.");
   }
 }


### PR DESCRIPTION
This assertion should not be using items.length since items will always be null here. This currently fails all cases where routeAndNavigatorSettings is not null.