### PR TITLE
Add popAllScreensForTheSelectedTab functionality for custom navbar

### DIFF
--- a/example/lib/custom-widget-tabs.widget.dart
+++ b/example/lib/custom-widget-tabs.widget.dart
@@ -126,6 +126,9 @@ class _CustomWidgetExampleState extends State<CustomWidgetExample> {
         context,
         controller: _controller,
         screens: _buildScreens(),
+        items: _buildScreens()
+            .map((e) => PersistentBottomNavBarItem.custom())
+            .toList(),
         confineInSafeArea: true,
         itemCount: 5,
         handleAndroidBackButtonPress: true,
@@ -137,9 +140,12 @@ class _CustomWidgetExampleState extends State<CustomWidgetExample> {
           curve: Curves.ease,
           duration: Duration(milliseconds: 200),
         ),
-        customWidget: CustomNavBarWidget(
+        customWidget: (NavBarEssentials navBarEssentials) => CustomNavBarWidget(
           items: _navBarsItems(),
           onItemSelected: (index) {
+            if (index == _controller.index)
+              navBarEssentials.popAllScreensForTheSelectedTab(index);
+
             setState(() {
               _controller.index = index; // THIS IS CRITICAL!! Don't miss it!
             });

--- a/lib/models/persisten-bottom-nav-item.widget.dart
+++ b/lib/models/persisten-bottom-nav-item.widget.dart
@@ -62,4 +62,18 @@ class PersistentBottomNavBarItem {
     assert(icon != null);
     assert(opacity >= 0 && opacity <= 1.0);
   }
+
+  PersistentBottomNavBarItem.custom(
+      {this.icon,
+      this.title,
+      this.contentPadding = 5.0,
+      this.activeColor = CupertinoColors.activeBlue,
+      this.activeColorAlternate,
+      this.opacity = 1.0,
+      this.inactiveColor,
+      this.filter,
+      this.textStyle,
+      this.iconSize = 26.0,
+      this.onSelectedTabPressWhenNoScreensPushed,
+      this.onPressed});
 }

--- a/lib/models/persistent-bottom-nav-bar.widget.dart
+++ b/lib/models/persistent-bottom-nav-bar.widget.dart
@@ -20,7 +20,7 @@ class PersistentBottomNavBar extends StatelessWidget {
   final NavBarDecoration navBarDecoration;
   final NavBarStyle navBarStyle;
   final NeumorphicProperties neumorphicProperties;
-  final Widget customNavBarWidget;
+  final Widget Function(NavBarEssentials navBarEssentials) customNavBarWidget;
   final bool confineToSafeArea;
   final bool hideNavigationBar;
   final Function(bool, bool) onAnimationComplete;
@@ -38,7 +38,7 @@ class PersistentBottomNavBar extends StatelessWidget {
                         : confineToSafeArea ?? true,
                     child: Container(
                       color: this.navBarEssentials.backgroundColor,
-                      child: this.customNavBarWidget,
+                      child: this.customNavBarWidget(navBarEssentials),
                     ),
                   )
                 : Container(
@@ -49,7 +49,7 @@ class PersistentBottomNavBar extends StatelessWidget {
                                 (this.hideNavigationBar ?? false)
                             ? false
                             : confineToSafeArea ?? true,
-                        child: this.customNavBarWidget),
+                        child: this.customNavBarWidget(navBarEssentials)),
                   )
             : this.navBarStyle == NavBarStyle.style15 ||
                     this.navBarStyle == NavBarStyle.style16
@@ -198,7 +198,7 @@ class PersistentBottomNavBar extends StatelessWidget {
 
   Widget getNavBarStyle() {
     if (isCustomWidget) {
-      return customNavBarWidget;
+      return this.customNavBarWidget(navBarEssentials);
     } else {
       switch (navBarStyle) {
         case NavBarStyle.style1:

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -140,49 +140,51 @@ class PersistentTabView extends PersistentTabViewBase {
         "Number of 'Navigator Keys' must be equal to the number of bottom navigation tabs.");
   }
 
-  PersistentTabView.custom(
-    this.context, {
-    Key key,
-    @required this.screens,
-    this.controller,
-    this.margin = EdgeInsets.zero,
-    this.floatingActionButton,
-    Widget customWidget,
-    int itemCount,
-    this.resizeToAvoidBottomInset = false,
-    this.bottomScreenMargin,
-    this.selectedTabScreenContext,
-    this.hideNavigationBarWhenKeyboardShows = true,
-    this.backgroundColor = CupertinoColors.white,
-    this.routeAndNavigatorSettings = const RouteAndNavigatorSettings(),
-    this.confineInSafeArea = true,
-    this.onWillPop,
-    this.stateManagement = true,
-    this.handleAndroidBackButtonPress = true,
-    this.hideNavigationBar,
-    this.screenTransitionAnimation = const ScreenTransitionAnimation(),
-  }) : super(
-          key: key,
-          context: context,
-          screens: screens,
-          controller: controller,
-          margin: margin,
-          routeAndNavigatorSettings: routeAndNavigatorSettings,
-          backgroundColor: backgroundColor,
-          floatingActionButton: floatingActionButton,
-          customWidget: customWidget,
-          itemCount: itemCount,
-          resizeToAvoidBottomInset: resizeToAvoidBottomInset,
-          bottomScreenMargin: bottomScreenMargin,
-          onWillPop: onWillPop,
-          confineInSafeArea: confineInSafeArea,
-          stateManagement: stateManagement,
-          handleAndroidBackButtonPress: handleAndroidBackButtonPress,
-          hideNavigationBar: hideNavigationBar,
-          screenTransitionAnimation: screenTransitionAnimation,
-          isCustomWidget: true,
-          decoration: NavBarDecoration(),
-        ) {
+  PersistentTabView.custom(this.context,
+      {Key key,
+      List<PersistentBottomNavBarItem> items,
+      @required this.screens,
+      this.controller,
+      this.margin = EdgeInsets.zero,
+      this.floatingActionButton,
+      Widget Function(NavBarEssentials navBarEssentials) customWidget,
+      int itemCount,
+      this.resizeToAvoidBottomInset = false,
+      this.bottomScreenMargin,
+      this.selectedTabScreenContext,
+      this.hideNavigationBarWhenKeyboardShows = true,
+      this.backgroundColor = CupertinoColors.white,
+      this.routeAndNavigatorSettings = const RouteAndNavigatorSettings(),
+      this.confineInSafeArea = true,
+      this.onWillPop,
+      this.stateManagement = true,
+      this.handleAndroidBackButtonPress = true,
+      this.hideNavigationBar,
+      this.screenTransitionAnimation = const ScreenTransitionAnimation(),
+      bool popAllScreensOnTapOfSelectedTab = true})
+      : super(
+            key: key,
+            items: items,
+            context: context,
+            screens: screens,
+            controller: controller,
+            margin: margin,
+            routeAndNavigatorSettings: routeAndNavigatorSettings,
+            backgroundColor: backgroundColor,
+            floatingActionButton: floatingActionButton,
+            customWidget: customWidget,
+            itemCount: itemCount,
+            resizeToAvoidBottomInset: resizeToAvoidBottomInset,
+            bottomScreenMargin: bottomScreenMargin,
+            onWillPop: onWillPop,
+            confineInSafeArea: confineInSafeArea,
+            stateManagement: stateManagement,
+            handleAndroidBackButtonPress: handleAndroidBackButtonPress,
+            hideNavigationBar: hideNavigationBar,
+            screenTransitionAnimation: screenTransitionAnimation,
+            isCustomWidget: true,
+            decoration: NavBarDecoration(),
+            popAllScreensOnTapOfSelectedTab: popAllScreensOnTapOfSelectedTab) {
     assert(itemCount != null,
         "In case of custom navigation bar style, the property itemCount is required!");
     assert(screens != null, "screens property is required");
@@ -242,7 +244,7 @@ class PersistentTabViewBase extends StatefulWidget {
   final EdgeInsets margin;
 
   ///Custom navigation bar widget. To be only used when `navBarStyle` is set to `NavBarStyle.custom`.
-  final Widget customWidget;
+  final Widget Function(NavBarEssentials navBarEssentials) customWidget;
 
   ///If using `custom` navBarStyle, define this instead of the `items` property
   final int itemCount;

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -197,6 +197,15 @@ class PersistentTabView extends PersistentTabViewBase {
             routeAndNavigatorSettings.navigatorKeys != null &&
                 routeAndNavigatorSettings.navigatorKeys.length != items.length,
         "Number of 'Navigator Keys' must be equal to the number of bottom navigation tabs.");
+    assert(popAllScreensOnTapOfSelectedTab != null,
+        'popAllScreensOnTapOfSelectedTab must not be null');
+    assert(
+        (popAllScreensOnTapOfSelectedTab &&
+                items != null &&
+                items.isNotEmpty &&
+                items.length == screens.length) ||
+            !popAllScreensOnTapOfSelectedTab,
+        "items must not be null/empty and should have the same length with the screens");
   }
 }
 


### PR DESCRIPTION
To enable custom navBars to pop all screens inside the tab when clicking the same nav/tab icon, the following are modified:

- Modify customWidget from **widget** to a **widget builder** 
```Widget Function(NavBarEssentials navBarEssentials) customWidget``` 
exposing **NavBarEssentials** 
- Added `bool popAllScreensOnTapOfSelectedTab = true` and `List<PersistentBottomNavBarItem> items` in `PersistentBottomNavBarItem.custom`

**Requirements:**
`popAllScreensOnTapOfSelectedTab == true` and `items = List<PersistentBottomNavBarItem> with length same with the screen`
```
       items: _buildScreens()
            .map((e) => PersistentBottomNavBarItem.custom())
            .toList(),
       .....
      customWidget: (NavBarEssentials navBarEssentials) => CustomNavBarWidget(
          items: _navBarsItems(),
          onItemSelected: (index) {
            if (index == _controller.index)
              navBarEssentials.popAllScreensForTheSelectedTab(index);

            setState(() {
              _controller.index = index; // THIS IS CRITICAL!! Don't miss it!
            });
          },
          selectedIndex: _controller.index,
        ),