### PR TITLE
`popAllScreensOnTapAnyTabs` option

### DIFF
--- a/lib/models/nav-bar-essentials.model.dart
+++ b/lib/models/nav-bar-essentials.model.dart
@@ -9,6 +9,7 @@ class NavBarEssentials {
   final double? navBarHeight;
   final NavBarPadding? padding;
   final bool? popScreensOnTapOfSelectedTab;
+  final bool? popAllScreensOnTapAnyTabs;
   final ItemAnimationProperties? itemAnimationProperties;
   final BuildContext? selectedScreenBuildContext;
 
@@ -18,6 +19,7 @@ class NavBarEssentials {
     this.previousIndex,
     this.backgroundColor,
     this.popScreensOnTapOfSelectedTab,
+    this.popAllScreensOnTapAnyTabs,
     this.itemAnimationProperties,
     this.navBarHeight = 0.0,
     required this.items,

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -81,6 +81,7 @@ class PersistentTabView extends PersistentTabViewBase {
       this.selectedTabScreenContext,
       this.hideNavigationBarWhenKeyboardShows = true,
       bool popAllScreensOnTapOfSelectedTab = true,
+      bool popAllScreensOnTapAnyTabs = false,
       PopActionScreensType popActionScreens = PopActionScreensType.all,
       this.confineInSafeArea = true,
       this.onWillPop,
@@ -105,6 +106,7 @@ class PersistentTabView extends PersistentTabViewBase {
           navBarStyle: navBarStyle,
           popActionScreens: popActionScreens,
           popAllScreensOnTapOfSelectedTab: popAllScreensOnTapOfSelectedTab,
+          popAllScreensOnTapAnyTabs: popAllScreensOnTapAnyTabs,
           navBarHeight: navBarHeight,
           backgroundColor: backgroundColor,
           onItemSelected: onItemSelected,
@@ -251,6 +253,9 @@ class PersistentTabViewBase extends StatefulWidget {
   ///If an already selected tab is pressed/tapped again, all the screens pushed on that particular tab will pop until the first screen in the stack. Defaults to `true`.
   final bool? popAllScreensOnTapOfSelectedTab;
 
+  ///All the screens pushed on that particular tab will pop until the first screen in the stack, whether the tab is already selected or not. Defaults to `false`.
+  final bool? popAllScreensOnTapAnyTabs;
+
   ///If set all pop until to first screen else set once pop once
   final PopActionScreensType? popActionScreens;
 
@@ -309,6 +314,7 @@ class PersistentTabViewBase extends StatefulWidget {
     this.customWidget,
     this.itemCount,
     this.popAllScreensOnTapOfSelectedTab,
+    this.popAllScreensOnTapAnyTabs,
     this.popActionScreens,
     this.onWillPop,
     this.hideNavigationBarWhenKeyboardShows,
@@ -591,13 +597,16 @@ class _PersistentTabViewState extends State<PersistentTabView> {
               navBarHeight: _navBarHeight,
               popScreensOnTapOfSelectedTab:
                   widget.popAllScreensOnTapOfSelectedTab ?? true,
+              popAllScreensOnTapAnyTabs:
+                  widget.popAllScreensOnTapAnyTabs ?? false,
               onItemSelected: widget.onItemSelected != null
                   ? (int index) {
                       if (_controller!.index != _previousIndex) {
                         _previousIndex = _controller!.index;
                       }
-                      if ((widget.popAllScreensOnTapOfSelectedTab ?? true) &&
-                          _previousIndex == index) {
+                      if (((widget.popAllScreensOnTapOfSelectedTab ?? true) &&
+                              _previousIndex == index) ||
+                          (widget.popAllScreensOnTapAnyTabs ?? false)) {
                         popAllScreens();
                       }
                       _controller!.index = index;
@@ -607,10 +616,12 @@ class _PersistentTabViewState extends State<PersistentTabView> {
                       if (_controller!.index != _previousIndex) {
                         _previousIndex = _controller!.index;
                       }
-                      if ((widget.popAllScreensOnTapOfSelectedTab ?? true) &&
-                          _previousIndex == index) {
+                      if (((widget.popAllScreensOnTapOfSelectedTab ?? true) &&
+                              _previousIndex == index) ||
+                          (widget.popAllScreensOnTapAnyTabs ?? false)) {
                         popAllScreens();
                       }
+                      // popAllScreens();
                       _controller!.index = index;
                     },
             ),
@@ -713,7 +724,8 @@ class _PersistentTabViewState extends State<PersistentTabView> {
   }
 
   void popAllScreens() {
-    if (widget.popAllScreensOnTapOfSelectedTab!) {
+    if (widget.popAllScreensOnTapOfSelectedTab! ||
+        widget.popAllScreensOnTapAnyTabs!) {
       if (widget.items![_controller!.index]
                   .onSelectedTabPressWhenNoScreensPushed !=
               null &&


### PR DESCRIPTION
In addition to the `popScreensOnTapOfSelectedTab`, this PR suggest to add a `popAllScreensOnTapAnyTabs` options (maybe it could have a better name if you have suggestions).

With this option enabled, all the screens pushed on that particular tab will pop until the first screen in the stack, whether the tab is already selected or not. Defaults to `false`.

