### PR TITLE
Added ability to change the nav bar height in custom styles

### DIFF
--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -152,6 +152,7 @@ class PersistentTabView extends PersistentTabViewBase {
     this.handleAndroidBackButtonPress = true,
     this.hideNavigationBar,
     this.screenTransitionAnimation = const ScreenTransitionAnimation(),
+    double navBarHeight = kBottomNavigationBarHeight,
   }) : super(
           key: key,
           context: context,
@@ -173,6 +174,7 @@ class PersistentTabView extends PersistentTabViewBase {
           screenTransitionAnimation: screenTransitionAnimation,
           isCustomWidget: true,
           decoration: NavBarDecoration(),
+          navBarHeight: navBarHeight,
         ) {
     assert(itemCount == screens.length,
         "screens and items length should be same. If you are using the onPressed callback function of 'PersistentBottomNavBarItem', enter a dummy screen like Container() in its place in the screens");


### PR DESCRIPTION
This PR adds the ability to change the navbar height when using a custom navbar.

Previously, only the non-custom navbar's height was able to change, while the custom nav was stuck at 56px.

Related to https://github.com/BilalShahid13/PersistentBottomNavBar/issues/160