### PR TITLE
Allowed page changing from outside & Fixed all the typos

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "cSpell.words": [
+        "Bilal",
+        "Cherepanov",
+        "neumorphic",
+        "Neumorphism",
+        "Shahid"
+    ]
+}

--- a/lib/models/persistent-bottom-nav-item.widget.dart
+++ b/lib/models/persistent-bottom-nav-item.widget.dart
@@ -35,7 +35,7 @@ class PersistentBottomNavBarItem {
 
   ///If you want custom behavior on a press of a NavBar item like display a modal screen, you can declare your logic here.
   ///
-  ///NOTE: This will override the default tab switiching behavior for this particular item.
+  ///NOTE: This will override the default tab switching behavior for this particular item.
   final Function(BuildContext?)? onPressed;
 
   ///Use it when you want to run some code when user presses the NavBar when on the initial screen of that respective tab. The inspiration was taken from the native iOS navigation bar behavior where when performing similar operation, you taken to the top of the list.

--- a/lib/models/persistent-nav-bar-scaffold.widget.dart
+++ b/lib/models/persistent-nav-bar-scaffold.widget.dart
@@ -316,10 +316,10 @@ class _TabSwitchingViewState extends State<_TabSwitchingView>
       key = UniqueKey();
     }
 
-    _initAniamtionControllers();
+    _initAnimationControllers();
   }
 
-  _initAniamtionControllers() {
+  _initAnimationControllers() {
     if (widget.screenTransitionAnimation!.animateTabTransition) {
       _animationControllers =
           List<AnimationController?>.filled(widget.tabCount!, null);
@@ -490,13 +490,13 @@ class _TabSwitchingViewState extends State<_TabSwitchingView>
     _animationValue = MediaQuery.of(context).size.width;
     if (_tabCount != widget.tabCount) {
       _tabCount = widget.tabCount;
-      _initAniamtionControllers();
+      _initAnimationControllers();
     }
     if (widget.screenTransitionAnimation!.animateTabTransition &&
             _animationControllers.first!.duration !=
                 widget.screenTransitionAnimation!.duration ||
         _animationCurve != widget.screenTransitionAnimation!.curve) {
-      _initAniamtionControllers();
+      _initAnimationControllers();
     }
     if (_showAnimation !=
         widget.screenTransitionAnimation!.animateTabTransition) {

--- a/lib/models/route-settings.model.dart
+++ b/lib/models/route-settings.model.dart
@@ -46,7 +46,7 @@ class RouteAndNavigatorSettings {
   }
 }
 
-class CutsomWidgetRouteAndNavigatorSettings {
+class CustomWidgetRouteAndNavigatorSettings {
   final String? defaultTitle;
 
   final Map<String, WidgetBuilder>? routes;
@@ -61,7 +61,7 @@ class CutsomWidgetRouteAndNavigatorSettings {
 
   final List<GlobalKey<NavigatorState>>? navigatorKeys;
 
-  const CutsomWidgetRouteAndNavigatorSettings({
+  const CustomWidgetRouteAndNavigatorSettings({
     this.defaultTitle,
     this.routes,
     this.onGenerateRoute,
@@ -71,7 +71,7 @@ class CutsomWidgetRouteAndNavigatorSettings {
     this.navigatorKeys,
   });
 
-  CutsomWidgetRouteAndNavigatorSettings copyWith({
+  CustomWidgetRouteAndNavigatorSettings copyWith({
     String? defaultTitle,
     Map<String, WidgetBuilder>? routes,
     RouteFactory? onGenerateRoute,
@@ -80,7 +80,7 @@ class CutsomWidgetRouteAndNavigatorSettings {
     List<NavigatorObserver>? navigatorObservers,
     List<GlobalKey<NavigatorState>>? navigatorKeys,
   }) {
-    return CutsomWidgetRouteAndNavigatorSettings(
+    return CustomWidgetRouteAndNavigatorSettings(
       defaultTitle: defaultTitle ?? this.defaultTitle,
       routes: routes ?? this.routes,
       onGenerateRoute: onGenerateRoute ?? this.onGenerateRoute,

--- a/lib/persistent-tab-view.dart
+++ b/lib/persistent-tab-view.dart
@@ -5,7 +5,6 @@ import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart' show CupertinoApp;
 
 //Main TabView Widget
 part 'persistent-tab-view.widget.dart';
@@ -13,7 +12,7 @@ part 'persistent-tab-view.widget.dart';
 //Models
 part 'models/persistent-nav-bar-scaffold.widget.dart';
 part 'models/persistent-bottom-nav-bar.widget.dart';
-part 'models/persisten-bottom-nav-item.widget.dart';
+part 'models/persistent-bottom-nav-item.widget.dart';
 part 'models/persistent-bottom-nav-bar-styles.widget.dart';
 part 'models/neumorphic-properties.widget.dart';
 part 'models/tab-view.widget.dart';
@@ -30,7 +29,7 @@ part 'utils/navigator-functions.utils.dart';
 //Animations
 part 'animations/animations.dart';
 
-//Neuomorphic-Card
+//Neumorphic-Card
 part 'neumorphic-package-by-serge-software/neumorphic-card.dart';
 
 //Styles

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -58,7 +58,7 @@ class PersistentTabView extends PersistentTabViewBase {
 
   final bool hideNavigationBarWhenKeyboardShows;
 
-  ///Hides the navigation bar with an transition animation. Use it in conjuction with [Provider](https://pub.dev/packages/provider) for better results.
+  ///Hides the navigation bar with an transition animation. Use it in conjunction with [Provider](https://pub.dev/packages/provider) for better results.
   final bool? hideNavigationBar;
 
   final BuildContext context;
@@ -150,8 +150,8 @@ class PersistentTabView extends PersistentTabViewBase {
     this.selectedTabScreenContext,
     this.hideNavigationBarWhenKeyboardShows = true,
     this.backgroundColor = CupertinoColors.white,
-    CutsomWidgetRouteAndNavigatorSettings routeAndNavigatorSettings =
-        const CutsomWidgetRouteAndNavigatorSettings(),
+    CustomWidgetRouteAndNavigatorSettings routeAndNavigatorSettings =
+        const CustomWidgetRouteAndNavigatorSettings(),
     this.confineInSafeArea = true,
     this.onWillPop,
     this.stateManagement = true,
@@ -279,13 +279,13 @@ class PersistentTabViewBase extends StatefulWidget {
   ///This controls the animation properties of the items of the NavBar.
   final ItemAnimationProperties? itemAnimationProperties;
 
-  ///Hides the navigation bar with an transition animation. Use it in conjuction with [Provider](https://pub.dev/packages/provider) for better results.
+  ///Hides the navigation bar with an transition animation. Use it in conjunction with [Provider](https://pub.dev/packages/provider) for better results.
   final bool? hideNavigationBar;
 
   ///Define navigation bar route name and settings here.
   ///
   ///If you want to programmatically pop to initial screen on a specific use this route name when popping.
-  final CutsomWidgetRouteAndNavigatorSettings? routeAndNavigatorSettings;
+  final CustomWidgetRouteAndNavigatorSettings? routeAndNavigatorSettings;
 
   final bool? isCustomWidget;
 

--- a/lib/persistent-tab-view.widget.dart
+++ b/lib/persistent-tab-view.widget.dart
@@ -72,6 +72,7 @@ class PersistentTabView extends PersistentTabViewBase {
       this.margin = EdgeInsets.zero,
       this.backgroundColor = CupertinoColors.white,
       ValueChanged<int>? onItemSelected,
+      bool manuallyHandelPageChange = false,
       NeumorphicProperties? neumorphicProperties,
       this.floatingActionButton,
       NavBarPadding padding = const NavBarPadding.all(null),
@@ -108,6 +109,7 @@ class PersistentTabView extends PersistentTabViewBase {
           navBarHeight: navBarHeight,
           backgroundColor: backgroundColor,
           onItemSelected: onItemSelected,
+          manuallyHandelPageChange: manuallyHandelPageChange,
           neumorphicProperties: neumorphicProperties,
           floatingActionButton: floatingActionButton,
           resizeToAvoidBottomInset: resizeToAvoidBottomInset,
@@ -128,6 +130,10 @@ class PersistentTabView extends PersistentTabViewBase {
         "screens and items length should be same. If you are using the onPressed callback function of 'PersistentBottomNavBarItem', enter a dummy screen like Container() in its place in the screens");
     assert(items!.length >= 2 && items.length <= 6,
         "NavBar should have at least 2 or maximum 6 items (Except for styles 15-18)");
+    assert(
+        (manuallyHandelPageChange && onItemSelected != null) ||
+            !manuallyHandelPageChange,
+        "You have to provide onItemSelected callback when yuo set manuallyHandelPageChange to be true");
   }
 
   PersistentTabView.custom(
@@ -200,6 +206,9 @@ class PersistentTabViewBase extends StatefulWidget {
 
   ///Callback when page or tab change is detected.
   final ValueChanged<int>? onItemSelected;
+
+  ///Disables the automatic page change done before `onItemSelected` is called, You will handel the page change manually inside `onItemSelected`.
+  final bool? manuallyHandelPageChange;
 
   ///Specifies the curve properties of the NavBar.
   final NavBarDecoration? decoration;
@@ -301,6 +310,7 @@ class PersistentTabViewBase extends StatefulWidget {
     this.items,
     this.backgroundColor,
     this.onItemSelected,
+    this.manuallyHandelPageChange,
     this.decoration,
     this.padding,
     this.navBarStyle,
@@ -593,14 +603,16 @@ class _PersistentTabViewState extends State<PersistentTabView> {
                   widget.popAllScreensOnTapOfSelectedTab ?? true,
               onItemSelected: widget.onItemSelected != null
                   ? (int index) {
-                      if (_controller!.index != _previousIndex) {
-                        _previousIndex = _controller!.index;
+                      if (!widget.manuallyHandelPageChange!) {
+                        if (_controller!.index != _previousIndex) {
+                          _previousIndex = _controller!.index;
+                        }
+                        if ((widget.popAllScreensOnTapOfSelectedTab ?? true) &&
+                            _previousIndex == index) {
+                          popAllScreens();
+                        }
+                        _controller!.index = index;
                       }
-                      if ((widget.popAllScreensOnTapOfSelectedTab ?? true) &&
-                          _previousIndex == index) {
-                        popAllScreens();
-                      }
-                      _controller!.index = index;
                       widget.onItemSelected!(index);
                     }
                   : (int index) {


### PR DESCRIPTION
Hello Dear,

In the Pull Request you will find 2 commits, one of them to allow the page changing from outside, and the second is just a fix for all the typos.

For the page changing, it was always handled automatically by the package from inside the class, my commit is adding a property called `manuallyHandelPageChange` to leave the control of page changing for the provided `onItemSelected` callback.

I hope you find this helpful.

Good Luck ❤