### PR TITLE
Fixed The OnWillPop Asset Error while Using Custom PersistentTabViewWidget

### DIFF
--- a/lib/persistent_tab_view.widget.dart
+++ b/lib/persistent_tab_view.widget.dart
@@ -104,7 +104,7 @@ class PersistentTabView extends PersistentTabViewBase {
     this.screenTransitionAnimation = const ScreenTransitionAnimation(),
   })  : assert(itemCount == screens.length,
             "screens and items length should be same. If you are using the onPressed callback function of 'PersistentBottomNavBarItem', enter a dummy screen like Container() in its place in the screens"),
-        assert(handleAndroidBackButtonPress && onWillPop != null,
+        assert(handleAndroidBackButtonPress && onWillPop == null,
             "If you declare the onWillPop function, you will have to handle the back function functionality yourself as your onWillPop function will override the defualt function."),
         super(
           key: key,


### PR DESCRIPTION
Fixed OnWillPop Assert Error When Using Custom Persistent Tab View by changing 
OnWillPop != null to OnWillPop == null 
To correct the condition which invoked the asset throw

